### PR TITLE
Graffiti: subgraph edge filtering

### DIFF
--- a/graffiti/graph/traversal/traversal.go
+++ b/graffiti/graph/traversal/traversal.go
@@ -1413,9 +1413,15 @@ func (tv *GraphTraversalV) SubGraph(ctx StepContext, s ...interface{}) *GraphTra
 		}
 	}
 
+	// Create a metadataEM for edges if it has been specified in the arguments
+	metadataEM, err := ParamsToElementMatcher(filters.BoolFilterOp_AND, s...)
+	if err != nil {
+		return &GraphTraversal{error: fmt.Errorf("Error creating the edge filter for the nodes subgraph: %s", err)}
+	}
+
 	// then insert edges, ignore edge insert error since one of the linked node couldn't be part
 	// of the SubGraph
-	edges := tv.GraphTraversal.Graph.GetNodesEdges(tv.nodes, nil)
+	edges := tv.GraphTraversal.Graph.GetNodesEdges(tv.nodes, metadataEM)
 	for _, e := range edges {
 		switch err := memory.EdgeAdded(e); err {
 		case nil, graph.ErrParentNotFound, graph.ErrChildNotFound, graph.ErrEdgeConflict:

--- a/graffiti/graph/traversal/traversal_test.go
+++ b/graffiti/graph/traversal/traversal_test.go
@@ -576,6 +576,26 @@ func TestTraversalSubGraph(t *testing.T) {
 	}
 }
 
+func TestTraversalSubGraphWithEdgeFilter(t *testing.T) {
+	g := newTransversalGraph(t)
+	ctx := StepContext{}
+
+	tr := NewGraphTraversal(g, false)
+
+	te := tr.V(ctx).SubGraph(ctx, "Name", Without("e2", "e3", "e4", "e5")).E(ctx)
+	if len(te.Values()) != 1 {
+		t.Fatalf("Should return 1 edge, returned: %v. Error = %v", te.Values(), te.Error())
+	}
+
+	name, err := te.Values()[0].(*graph.Edge).Metadata.GetFieldString("Name")
+	if err != nil {
+		t.Fatalf("Should return a Name field, returned an error: %s", err)
+	}
+	if name != "e1" {
+		t.Fatalf("Should return a edge with Name e1, returned: %v, %s", te.Values(), te.Error())
+	}
+}
+
 func execTraversalQuery(t *testing.T, g *graph.Graph, query string) GraphTraversalStep {
 	ts, err := NewGremlinTraversalParser().Parse(strings.NewReader(query))
 	if err != nil {


### PR DESCRIPTION
When using Subgraph() with nodes (G.V().SubGraph()), now it is possible to filter which edges we want to return, instead of all connecting the selected nodes.

For example, if we have two nodes, A and B, and two edges between them, "e1" and "e1", now we can use this syntaxis to just return the edge "e1".

G.V().SubGraph("Name", "e1")

The syntaxis inside of SubGraph is the same as in 'Has'.